### PR TITLE
Show both test and pipeline times

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,8 +2,11 @@
 
 require 'sinatra'
 require_relative 'lib/integration_suite'
+require_relative 'helpers/view_helpers'
 
 set :public_folder, "#{__dir__}/static"
+
+helpers ViewHelpers
 
 get '/' do
   pipelines, flaky_tests = IntegrationSuite.compile_pipelines(params)

--- a/helpers/view_helpers.rb
+++ b/helpers/view_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Provides utility methods for formatting and extracting
+# pipeline and job information for use in view templates.
 module ViewHelpers
   # Returns the pipeline duration in minutes, rounded up, or '?' if not available
   def pipeline_duration_minutes(pipeline)

--- a/helpers/view_helpers.rb
+++ b/helpers/view_helpers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ViewHelpers
+  # Returns the pipeline duration in minutes, rounded up, or '?' if not available
+  def pipeline_duration_minutes(pipeline)
+    return '?' unless pipeline['duration']
+
+    ((pipeline['duration'] / 60) + 1)
+  end
+end

--- a/helpers/view_helpers.rb
+++ b/helpers/view_helpers.rb
@@ -5,6 +5,14 @@ module ViewHelpers
   def pipeline_duration_minutes(pipeline)
     return '?' unless pipeline['duration']
 
-    ((pipeline['duration'] / 60) + 1)
+    (pipeline['duration'] / 60.0).ceil.to_i
+  end
+
+  # Returns the test duration in minutes, or nil if not available
+  def test_duration_minutes(pipeline)
+    pipeline['jobs']
+      .select { |job| job['name'].include?('test') && job['duration'] }
+      .map { |job| (job['duration'] / 60.0).ceil.to_i }
+      .max
   end
 end

--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ViewHelpers do
   let(:helper) { Class.new { extend ViewHelpers } }
 
   describe '#pipeline_duration_minutes' do
-    let(:pipeline) { build(:pipeline, duration: 23 * 60 + 30) }
+    let(:pipeline) { build(:pipeline, duration: (23 * 60) + 30) }
 
     context 'when duration is nil' do
       let(:pipeline) { build(:pipeline, duration: nil) }

--- a/spec/helpers/view_helpers_spec.rb
+++ b/spec/helpers/view_helpers_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require './helpers/view_helpers'
+
+RSpec.describe ViewHelpers do
+  let(:helper) { Class.new { extend ViewHelpers } }
+
+  describe '#pipeline_duration_minutes' do
+    let(:pipeline) { build(:pipeline, duration: 23 * 60 + 30) }
+
+    context 'when duration is nil' do
+      let(:pipeline) { build(:pipeline, duration: nil) }
+
+      it 'returns "?"' do
+        expect(helper.pipeline_duration_minutes(pipeline)).to eq('?')
+      end
+    end
+
+    it 'returns the duration in minutes rounded up' do
+      expect(helper.pipeline_duration_minutes(pipeline)).to eq(24)
+    end
+  end
+
+  describe '#test_duration_minutes' do
+    let(:pipeline) { build(:pipeline, jobs: jobs) }
+
+    context 'when no test jobs are present' do
+      let(:jobs) { [] }
+
+      it 'returns nil' do
+        expect(helper.test_duration_minutes(pipeline)).to be_nil
+      end
+    end
+
+    context 'when test jobs are present' do
+      let(:jobs) do
+        [
+          { 'name' => 'test_job_1', 'duration' => 120 },
+          { 'name' => 'test_job_2', 'duration' => 181 }
+        ]
+      end
+
+      it 'returns the maximum test duration in minutes rounded up' do
+        expect(helper.test_duration_minutes(pipeline)).to eq(4)
+      end
+    end
+  end
+end

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -146,7 +146,7 @@
                       <strong><%= pipeline['overall_status'].capitalize %></strong>
                     </span>
                     <span class="text-secondary float-end" title="<%= pipeline['job_times'] %>">
-                      <%= pipeline['duration'] ? ((pipeline['duration'] / 60) + 1) : '?' %> mins
+                      <%= pipeline_duration_minutes(pipeline) %> mins
                     </span>
                   </span>
                 </div>

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -145,8 +145,12 @@
                     <span class="status-<%= pipeline['status'].downcase %> float-end ms-3">
                       <strong><%= pipeline['overall_status'].capitalize %></strong>
                     </span>
-                    <span class="text-secondary float-end" title="<%= pipeline['job_times'] %>">
-                      <%= pipeline_duration_minutes(pipeline) %> mins
+                    <span class="text-secondary float-end" title="<%= "test-pipeline mins\n\n#{pipeline['job_times']}" %>">
+                      <% if test_duration_minutes(pipeline) %>
+                        <%= test_duration_minutes(pipeline) %>-<%= pipeline_duration_minutes(pipeline) %> mins
+                      <% else %>
+                        <%= pipeline_duration_minutes(pipeline) %> mins
+                      <% end %>
                     </span>
                   </span>
                 </div>


### PR DESCRIPTION
Show both test and pipeline times for easy performance monitoring

#### Changes proposed in this pull request

- Extracts time calculations into helpers
- Adds tests for helpers
- Adds additional time display `25-29`
  - the first number is the maximum time of any single` job_test`
  - the second number is the time taken to run the whole pipeline
 
Screenshot:
<img width="1095" height="446" alt="Screenshot 2025-08-13 at 13 52 10" src="https://github.com/user-attachments/assets/5a68b319-8846-44c2-85fc-8d39b2c70c77" />



#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
